### PR TITLE
Re-add Ruby head version to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        ruby: [ 2.5, 2.6, 2.7, '3.0', truffleruby, truffleruby-head, jruby, jruby-head ]
+        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head, truffleruby, truffleruby-head, jruby, jruby-head ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -22,3 +22,4 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - run: bundle exec rake
+        continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,8 +29,20 @@ class Minitest::Test
         ActiveRecord::Base.connection.tables
       end
 
+
     tables.each do |table|
-      ActiveRecord::Base.connection.truncate(table)
+      if ActiveRecord::VERSION::MAJOR > 5
+        ActiveRecord::Base.connection.truncate(table)
+      else
+        case ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+        when :mysql2 || :postgresql
+          ActiveRecord::Base.connection.execute("TRUNCATE #{ActiveRecord::Base.connection.quote_table_name(table)}")
+        when :sqlite
+          ActiveRecord::Base.connection.execute("DELETE FROM #{ActiveRecord::Base.connection.quote_table_name(table)}")
+        else
+          raise NotImplementedError
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Also adds all supported ruby versions to the CI pipeline and allows failures of head rubies.